### PR TITLE
fix 'should be able to create a new order' test

### DIFF
--- a/src/__tests__/App.spec.ts
+++ b/src/__tests__/App.spec.ts
@@ -145,7 +145,7 @@ describe('App', () => {
         order_products: expect.arrayContaining([
           expect.objectContaining({
             product_id: product.body.id,
-            price: '500.00',
+            price: 500,
             quantity: 5,
           }),
         ]),
@@ -299,7 +299,7 @@ describe('App', () => {
         order_products: expect.arrayContaining([
           expect.objectContaining({
             product_id: product.body.id,
-            price: '500.00',
+            price: 500,
             quantity: 5,
           }),
         ]),


### PR DESCRIPTION
the test 'should be able to create a new order' expects the price as a string but the correct thing is to expect a number